### PR TITLE
Correct array list empty error

### DIFF
--- a/lambda_backup.py
+++ b/lambda_backup.py
@@ -81,14 +81,15 @@ def check_command(command_id, instance_id):
             Details=False
             )
         if check_response(response_iterator):
-            response_iterator_status = response_iterator['CommandInvocations'][0]['Status']
-            if response_iterator_status != 'Pending':
-                if response_iterator_status == 'InProgress' or response_iterator_status == 'Success':
-                    logging.info( "Status: %s", response_iterator_status)
-                    return True
-                else:
-                    logging.error("ERROR: status: %s", response_iterator)
-                    return False
+            if response_iterator['CommandInvocations']:
+              response_iterator_status = response_iterator['CommandInvocations'][0]['Status']
+              if response_iterator_status != 'Pending':
+                  if response_iterator_status == 'InProgress' or response_iterator_status == 'Success':
+                      logging.info( "Status: %s", response_iterator_status)
+                      return True
+                  else:
+                      logging.error("ERROR: status: %s", response_iterator)
+                      return False
         time.sleep(timewait)
         timewait += timewait
 


### PR DESCRIPTION
While the command history is not yet updated, we will get empty result for CommandInvocations, in this case, we need to wait a little and do a retry. Here, the sleep is not useful except we verify the CommandInvocations is not empty

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
